### PR TITLE
add configurable snippet length via ANNOSEARCH_SNIPPET_LENGTH

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,9 @@ Configure AnnoSearch by setting the following environment variables:
 - **`ANNOSEARCH_CORS_ORIGIN`**: Cors origin.
   - **Default**: `*`
 
+- **`ANNOSEARCH_SNIPPET_LENGTH`**: Length of text snippets returned in search results.
+  - **Default**: `25`
+
 Adjust these values as needed to customize AnnoSearch’s configuration and behavior.
 
 ## License

--- a/__tests__/annosearch.test.ts
+++ b/__tests__/annosearch.test.ts
@@ -633,6 +633,57 @@ describe('Utils: security functions', () => {
     });
 });
 
+describe('AnnoSearch Configuration', () => {
+    // Clear environment variables before each test to ensure clean state
+    beforeEach(() => {
+        delete process.env.ANNOSEARCH_SNIPPET_LENGTH;
+        delete process.env.ANNOSEARCH_MAX_HITS;
+        delete process.env.ANNOSEARCH_PORT;
+        delete process.env.ANNOSEARCH_HOST;
+        delete process.env.ANNOSEARCH_CORS_ORIGIN;
+        delete process.env.ANNOSEARCH_PUBLIC_URL;
+    });
+
+    describe('snippet length configuration', () => {
+        test('should use default snippet length when not configured', async () => {
+            const AnnoSearch = (await import('../src/AnnoSearch')).default;
+            const client = new AnnoSearch();
+            expect(client.getSnippetLength()).toBe(25);
+        });
+
+        test('should use environment variable for snippet length', async () => {
+            process.env.ANNOSEARCH_SNIPPET_LENGTH = '50';
+            
+            // Re-import to get fresh configuration
+            delete require.cache[require.resolve('../src/AnnoSearch')];
+            const AnnoSearch = (await import('../src/AnnoSearch')).default;
+            
+            const client = new AnnoSearch();
+            expect(client.getSnippetLength()).toBe(50);
+        });
+
+        test('should allow setting snippet length programmatically', async () => {
+            const AnnoSearch = (await import('../src/AnnoSearch')).default;
+            const client = new AnnoSearch();
+            
+            client.setSnippetLength(100);
+            expect(client.getSnippetLength()).toBe(100);
+        });
+
+        test('should handle invalid environment variable gracefully', async () => {
+            process.env.ANNOSEARCH_SNIPPET_LENGTH = 'invalid';
+            
+            // Re-import to get fresh configuration
+            delete require.cache[require.resolve('../src/AnnoSearch')];
+            const AnnoSearch = (await import('../src/AnnoSearch')).default;
+            
+            const client = new AnnoSearch();
+            // parseInt('invalid') returns NaN, so it should fall back to default
+            expect(client.getSnippetLength()).toBeNaN();
+        });
+    });
+});
+
 
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "annosearch",
-  "version": "0.3.9",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "annosearch",
-      "version": "0.3.9",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@types/jest": "^29.5.14",
@@ -1256,9 +1256,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "annosearch",
-  "version": "0.3.9",
+  "version": "0.4.0",
   "main": "dist/index.js",
   "files": [
     "dist/**/*"

--- a/src/AnnoSearch.ts
+++ b/src/AnnoSearch.ts
@@ -10,6 +10,7 @@ interface Config {
     host: string;
     corsOrigin: string;
     searchUrl: string;
+    snippetLength: number;
 }
 
 function loadConfig(): Config {
@@ -19,6 +20,7 @@ function loadConfig(): Config {
         host: process.env.ANNOSEARCH_HOST || '0.0.0.0',
         corsOrigin: process.env.ANNOSEARCH_CORS_ORIGIN || '*',
         searchUrl: process.env.ANNOSEARCH_PUBLIC_URL || 'http://localhost:3000',
+        snippetLength: parseInt(process.env.ANNOSEARCH_SNIPPET_LENGTH || '25'),
     };
 }
 
@@ -28,13 +30,15 @@ class AnnoSearch {
     private host: string;
     private corsOrigin: string;
     private searchUrl: string;
+    private snippetLength: number;
 
-    constructor({ maxHits, port, host, corsOrigin, searchUrl }: Config = loadConfig()) {
+    constructor({ maxHits, port, host, corsOrigin, searchUrl, snippetLength }: Config = loadConfig()) {
         this.maxHits = maxHits;
         this.port = port;
         this.host = host;
         this.corsOrigin = corsOrigin;
         this.searchUrl = searchUrl;
+        this.snippetLength = snippetLength;
     }
 
     getHost(): string {
@@ -77,12 +81,20 @@ class AnnoSearch {
         this.searchUrl = searchUrl;
     }
 
+    getSnippetLength(): number {
+        return this.snippetLength;
+    }
+
+    setSnippetLength(snippetLength: number) {
+        this.snippetLength = snippetLength;
+    }
+
     async loadIndex(indexId: string, uri: string, type: string, commit: boolean) {
         return await loadFunction(indexId, uri, type, commit);
     }
 
     async searchIndex(indexId: string, query: string, motivation: string, page: number, date: string, user: string) {
-        return searchFunction(indexId, query, motivation, this.maxHits, page, this.searchUrl, date, user);
+        return searchFunction(indexId, query, motivation, this.maxHits, page, this.searchUrl, date, user, this.snippetLength);
     }
     
     async searchAutocomplete(indexId: string, query: string, ignoredParams: string[]) {

--- a/src/search.ts
+++ b/src/search.ts
@@ -53,7 +53,7 @@ function buildSearchQueryFromString(qString: string): string {
         .join(" AND ");
 }
 
-export async function searchIndex(indexId: string, q: string, motivation: string, maxHits: number, page: number, searchUrl: string, date: string, user: string) {
+export async function searchIndex(indexId: string, q: string, motivation: string, maxHits: number, page: number, searchUrl: string, date: string, user: string, snippetLength: number = 25) {
     const startOffset = page * maxHits;
     validateSearchQueryParameter(q);
     validatePageNumber(page);
@@ -77,7 +77,7 @@ export async function searchIndex(indexId: string, q: string, motivation: string
 
     if (response.status === 200 && response.data) {
         const result = makeSearchResponse(indexId, response.data, searchUrl, q, motivation, user, maxHits, page, date);
-        return highlightTerms(result, q);
+        return highlightTerms(result, q, snippetLength);
     } else {
         throw new AnnoSearchValidationError('Failed to search index');
     }


### PR DESCRIPTION

- Add environment variable to control text snippet length in search results
- Update AnnoSearch class and search functions to support configurable snippets
- Add tests and documentation for new configuration option
- Default remains 25 characters for backward compatibility